### PR TITLE
fix ^ accent on tope là badge

### DIFF
--- a/web/conf/messages.fr
+++ b/web/conf/messages.fr
@@ -281,7 +281,7 @@ badge.solidary=Solidaire
 badge.candle=Bougie
 badge.invitation=Parrain
 badge.lucky=Porte-bonheur
-badge.high_five=Tôpe là !
+badge.high_five=Tope là !
 
 # Errors
 validation.required=Obligatoire


### PR DESCRIPTION
cause since 1713 (Hamilton, Gram., XI ds Littré: Il tôpait partout) 'tope' seems to have lost is ^ 
:)